### PR TITLE
Fix 4k playback EPL.

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1015,7 +1015,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
         // the minimum size.
         return max(
             HEVC_MAX_INPUT_SIZE_THRESHOLD,
-            getMaxSampleSize(/* pixelCount= */ width * height, /* minCompressionRatio= */ 2));
+            getMaxSampleSize(/* pixelCount= */ width * height, /* minCompressionRatio= */ 4));
       case MimeTypes.VIDEO_H264:
         if ("BRAVIA 4K 2015".equals(Util.MODEL) // Sony Bravia 4K
             || ("Amazon".equals(Util.MANUFACTURER)


### PR DESCRIPTION
This effectively reverts this commit for H265 only. https://github.com/google/ExoPlayer/commit/909953b84a3143dc08582feaae9c51acba04c66d?diff=split